### PR TITLE
Fix crash on position being string

### DIFF
--- a/src/Models/Casts/CastAmastyLabelVariables.php
+++ b/src/Models/Casts/CastAmastyLabelVariables.php
@@ -38,6 +38,9 @@ class CastAmastyLabelVariables implements CastsAttributes
             }
 
             foreach (['cat_position', 'prod_position'] as $typeLabel) {
+                if (!is_int($labels[$key]->{$typeLabel})) {
+		            continue;
+		        }
                 $labels[$key]->{$typeLabel} = $this->getPositionName($labels[$key]->{$typeLabel});
             }
         }

--- a/src/Models/Casts/CastAmastyLabelVariables.php
+++ b/src/Models/Casts/CastAmastyLabelVariables.php
@@ -39,8 +39,8 @@ class CastAmastyLabelVariables implements CastsAttributes
 
             foreach (['cat_position', 'prod_position'] as $typeLabel) {
                 if (!is_int($labels[$key]->{$typeLabel})) {
-		            continue;
-		        }
+                    continue;
+                }
                 $labels[$key]->{$typeLabel} = $this->getPositionName($labels[$key]->{$typeLabel});
             }
         }


### PR DESCRIPTION
A situation can and has occurred where the position is already the translated position value causing a crash.
This fixes that crash by only translating the position if it is an int