### PR TITLE
Reintroduced variables to amasty labels

### DIFF
--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -1,0 +1,23 @@
+window.amLabelReplaceVariables = (labeltext, product = null) => {
+    product ??= window.config?.product
+
+    if (!product) {
+        return labeltext
+    }
+
+    return labeltext.replaceAll(/(?<replace>{(?<variable>[^\}]*)})/g, (match, replace, input) => {
+        switch(input) {
+            case 'SPECIAL_PRICE': return window.price(window.productSpecialPrice(product) || window.productPrice(product))
+            case 'PRICE': return window.price(window.productPrice(product))
+            case 'SAVE_PERCENT': return Math.ceil(100 - ((window.productSpecialPrice(product) || window.productPrice(product)) * 100) / window.productPrice(product)) + '%'
+            case 'SAVE_AMOUNT': return window.price((window.productSpecialPrice(product) || window.productPrice(product)) - window.productPrice(product))
+            case 'SKU': return product.sku
+            case 'STOCK': return product.stock?.qty ?? ''
+            default:
+                 if (input.startsWith('ATTR:')) {
+                    return product[input.substring(5)] ?? ''
+                }
+                return ''
+        }
+    })
+}

--- a/resources/views/category.blade.php
+++ b/resources/views/category.blade.php
@@ -18,11 +18,11 @@
                 <img
                     loading="lazy"
                     v-bind:src="resizedPath(window.config.magento_url + (label.image.startsWith('/') ? label.image : '/media/amasty/amlabel/' + label.image) + '.webp', '200')"
-                    v-bind:alt="label.alt_tag || label.label_text"
+                    v-bind:alt="window.amLabelReplaceVariables(label.alt_tag || label.label_text, item)"
                 />
             </picture>
             <span v-bind:class="{'absolute top-1/2 left-1/2 text-center -translate-x-1/2 -translate-y-1/2': label.image}">
-                @{{ label.label_text }}
+                @{{ window.amLabelReplaceVariables(label.label_text, item) }}
             </span>
         </div>
     </div>

--- a/resources/views/product.blade.php
+++ b/resources/views/product.blade.php
@@ -32,7 +32,7 @@
                 @endif
                 <span @class([
                     'absolute top-1/2 left-1/2 text-center -translate-x-1/2 -translate-y-1/2' => $label->image
-                ])>{{ $label->label_text }}</span>
+                ]) v-txt="window.amLabelReplaceVariables('{{ $label->label_text }}')">{{ $label->label_text }}</span>
             </div>
         @endforeach
     </div>


### PR DESCRIPTION
With the V5 update it got removed
This re-introduces the variables, purposefully choosing to fill the variables using JS for customer (group) specific pricing.

ref: RAP-1694